### PR TITLE
_toolBarIcon definition changed in Glyphs3.

### DIFF
--- a/SuperTool/SuperTool.m
+++ b/SuperTool/SuperTool.m
@@ -20,6 +20,8 @@
 #import "SuperTool+Callipers.h"
 #import "SuperTool+Coverage.h"
 
+static NSImage *_toolBarIcon = nil;
+
 @implementation SuperTool
 
 - (id)init {


### PR DESCRIPTION
This might fix the recent issue of SuperTool not loading in the Glyphs3 beta.

_toolBarIcon needs to be defined in the plugins, now.
